### PR TITLE
Bash error handle

### DIFF
--- a/pyphs/numerics/cpp/simu2cpp.py
+++ b/pyphs/numerics/cpp/simu2cpp.py
@@ -35,6 +35,8 @@ def simu2cpp(simu):
     f = open(simu.run_script_path, 'w+')
     f.write(simu.run_script)
     f.close()
+
+    # Enables execution (chmod)
     make_executable(simu.run_script_path)
     make_executable(simu.cmakelists_path)
 
@@ -42,17 +44,44 @@ def simu2cpp(simu):
 def bash_script_template(path, label, cmakepath):
     return """#!/bin/sh
 
+### ERROR TRACKING ###
+# Stops bash script if an error occurs
+set -e
+
 # chg dir to app dir
 cd {0}
 
+# Check if stderr already exists, and deletes it
+if [ -e stderr ]
+then
+    rm stderr
+else
+    echo "creating stderr"
+fi
+
+
+# Create stderr file, for error tracking
+touch stderr
+echo "stderr: init" >> stderr
+
+
+### CMake Build ###
+echo "stderr: step 1 - cd to folder" >> stderr
+
 # CMake Build
+echo "stderr: step 2 - Cmake Build" >> stderr
 {3} . -Bbuild
 
 # Binary Build
+echo "stderr: step 3 - Binary Build" >> stderr
 {3} --build build -- -j3
 
 # Binary Exec
+echo "stderr: step 4 - Exec" >> stderr
 .{1}bin{1}{2}
+
+### END ###
+echo "stderr: end" >> stderr
 
         """.format(path,
                    os.path.sep,

--- a/pyphs/numerics/simulations/simulation.py
+++ b/pyphs/numerics/simulations/simulation.py
@@ -363,8 +363,29 @@ class Simulation:
         # execute the bash script
         self.system_call('./run.sh')
 
+        # Check if an error occured outside python (bash)
+        self._check_cpp_runtime_errors()
+        
+        # Removes the error file if everything went well
+        os.remove('stderr')
+
         # go back to work folder
         os.chdir(self.work_path)
+
+    def _check_cpp_runtime_errors(self):
+        
+        # Reading everyline of the error file in a list 
+        with open('stderr', 'r') as err_file:
+            stdError = err_file.readlines()
+
+        # Removing format characters (\n ...)
+        stdError = [line.strip() for line in stdError]
+
+        # Check if every step happened, otherwise, throws an error
+        if not 'stderr: end' in stdError:
+            raise RuntimeError(\
+'Bash/Cmake error while trying to compile cpp simulation: see file '
+                               + os.path.join(self.cpp_path, stdError[-1]))
 
     @staticmethod
     def system_call(cmd):


### PR DESCRIPTION
This PR is a first fix designed to catch compilation errors when using the C++ feature on PyPHS.

-------------------------
## Principle
It relies on a temporary file, `stderr`, created in the same folder as `run.sh`.

When running a `C++` based simulation, PyPHS execute a shell script that is the interface between Python and the CMake compiler. Every step is logged in `stderr`.  After the compilation step, Python check for the log:
```
stderr: end
```
if this line doesn't appear in the `stderr` file, python raise a RuntimeError, and the last line of the file, which contains the last step that caused the error.

----------------
## Implementation
### Shell script 
`pyphs/numerics/cpp/simu2cpp.py`
* the `set -e` command affects the behavior of the script: if an error is encountered, bash stops the execution of the script.
* The potentially previous `stderr` file is removed (`if fi` control structure)
* Every step is logged in this file: `echo "stderr: step n - doing stuff" > stderr`
* Confirmation step: inserting `stderr: end` at the end of the file

### Error checking 
`pyphs/numerics/simulations/simulation.py`
* Python reads the file line by line
* Removes the unnecessary characters
* Check if `stderr: end` is in the list
* Raise an error if not, with the last line of the stderr

--------------------
## Drawbacks
This implementation is not the best, but it was the one that required the least amount of time. Some ideas:
* Is the `RuntimeError` the correct exception to raise?
* Use the actual `stdout` or `stderr` created by the execution of bash file. I tried to work with that, but couldn't figure it out.
* I am not sure about the flexibility of this method